### PR TITLE
Issue #2998: workaround for buggy angular ng-src implementation (was: upload logo for theme customization not functional)

### DIFF
--- a/client/views/settings/website-management/manage-theme-settings.html
+++ b/client/views/settings/website-management/manage-theme-settings.html
@@ -10,7 +10,7 @@
                     ng-if="webPublisherSettings.themeSettings.theme_logo.value && !webPublisherSettings.replace_theme_logo"
                     ng-click="webPublisherSettings.replace_theme_logo = true">
                     <i class="icon-pencil"></i>
-                    <img ng-src="{{'https://' + newSite.subdomain + '.' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo.value}}" style="max-width:100%" />
+                    <img ng-src="http://{{newSite.subdomain && newSite.subdomain.length > 0 ? newSite.subdomain + '.' : '' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo.value}}" style="max-width:100%" />
                 </div>
                 <div class="wizardThemeBox wizardThemeBox--upload"
                 ng-if="!webPublisherSettings.themeSettings.theme_logo.value || webPublisherSettings.replace_theme_logo">
@@ -34,7 +34,7 @@
                     ng-if="webPublisherSettings.themeSettings.theme_logo_second.value && !webPublisherSettings.replace_theme_logo_second"
                     ng-click="webPublisherSettings.replace_theme_logo_second = true">
                     <i class="icon-pencil"></i>
-                    <img ng-src="{{'https://' + newSite.subdomain + '.' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo_second.value}}" style="max-width:100%" />
+                     <img ng-src="http://{{newSite.subdomain && newSite.subdomain.length > 0 ? newSite.subdomain + '.' : '' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo_second.value}}" style="max-width:100%" />
                 </div>
                 <div class="wizardThemeBox wizardThemeBox--upload"
                     ng-if="!webPublisherSettings.themeSettings.theme_logo_second.value || webPublisherSettings.replace_theme_logo_second">
@@ -58,7 +58,7 @@
                     ng-if="webPublisherSettings.themeSettings.theme_logo_third.value && !webPublisherSettings.replace_theme_logo_third"
                     ng-click="webPublisherSettings.replace_theme_logo_third = true">
                     <i class="icon-pencil"></i>
-                    <img ng-src="{{'https://' + newSite.subdomain + '.' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo_third.value}}" style="max-width:100%" />
+                    <img ng-src="http://{{newSite.subdomain && newSite.subdomain.length > 0 ? newSite.subdomain + '.' : '' + newSite.domainName + '/theme_logo/' + webPublisherSettings.themeSettings.theme_logo_third.value}}" style="max-width:100%" />
                 </div>
                 <div class="wizardThemeBox wizardThemeBox--upload"
                     ng-if="!webPublisherSettings.themeSettings.theme_logo_third.value || webPublisherSettings.replace_theme_logo_third">


### PR DESCRIPTION
It turns out the problem was displaying the iconic version of logos. The upload to the website was functional. It is a problem caused by the angular ng-src implementation. Now works by pulling out  "http://"  from the {{}} expression.

Actually should be using config'ed protocol, but that is not available in 'site'.