### PR TITLE
Check if subdomain is undefined/null before adding it to apiUrl

### DIFF
--- a/client/components/TargetedPublishing/Destination.jsx
+++ b/client/components/TargetedPublishing/Destination.jsx
@@ -69,7 +69,9 @@ class Destination extends Component {
       originalDestination: destination ? destination : {},
       destination: destination ? JSON.parse(JSON.stringify(destination)) : {},
       apiUrl: protocol
-        ? `${protocol}://${subdomain}.${domainName}/api/v1/`
+        ? `${protocol}://${
+            subdomain ? subdomain + "." : ""
+          }${domainName}/api/v1/`
         : "",
       subdomain: subdomain ? subdomain : "",
       domainName: domainName ? domainName : "",
@@ -136,7 +138,9 @@ class Destination extends Component {
         {
           originalDestination: destination,
           destination: JSON.parse(JSON.stringify(destination)),
-          apiUrl: `${protocol}://${subdomain}.${domainName}/api/v1/`,
+          apiUrl: `${protocol}://${
+            subdomain ? subdomain + "." : ""
+          }.${domainName}/api/v1/`,
           subdomain: subdomain,
           domainName: domainName,
           hasOutputChannel: hasOutputChannel,


### PR DESCRIPTION
# What does this PR do?

It checks if `subdomain` is undefined/null before adding it to the `apiUrl`. If it isn't available it isn't added.


# Why was this PR needed?

If no subdomain was set in config the apiUrl would contain a leading `.` which would cause the request to fail.

Before this pull request:

```
http://.192.168.102.2/api/v1
       ^
```

After this pull request:

```
http://192.168.102.2/api/v1
```


# How can this PR be tested?

Connect a publisher instance without a subdomain to superdesk and try to list the routes of the instance.

# Screenshots (if relevant)

<img width="325" alt="Skärmavbild 2019-10-01 kl  08 38 25" src="https://user-images.githubusercontent.com/52966/65939693-e1d16f00-e426-11e9-8c29-bf71c9446550.png">
