### PR TITLE
Output Control UI improvements and fixes

### DIFF
--- a/client/components/Output/Listing.jsx
+++ b/client/components/Output/Listing.jsx
@@ -292,7 +292,7 @@ class Listing extends React.Component {
           </div>
         ) : null}
 
-        {this.state.loading && <div className="sd-loader" />}
+        {this.state.loading && <div className="sd-loader" style={{ zIndex: "1" }} />}
       </div>
     );
   }

--- a/client/components/Output/Subnav.jsx
+++ b/client/components/Output/Subnav.jsx
@@ -23,7 +23,7 @@ const Subnav = props => {
                   />
                 </span>
 
-                <span sd-tooltip="Published" flow="right">
+                <span sd-tooltip="Published" flow="right" className="sd-margin-l--0-5">
                   <CheckButton
                     label={<i className="icon-expand-thin" />}
                     onClick={() => store.actions.setSelectedList("published")}

--- a/client/components/Output/TenantSelect.jsx
+++ b/client/components/Output/TenantSelect.jsx
@@ -21,9 +21,7 @@ const TenantSelect = props => {
     <React.Fragment>
       <div className="subnav__spacer subnav__spacer--no-margin" />
       <div
-        className={classNames("subnav__content-bar sd-flex-no-shrink", {
-          "sd-margin-l--1 sd-margin-r--1": store.isSuperdeskEditorOpen
-        })}
+        className={classNames("subnav__content-bar sd-flex-no-shrink sd-margin-x--0")}
       >
         <DropdownScrollable
           button={

--- a/client/styles/helperElements.scss
+++ b/client/styles/helperElements.scss
@@ -284,4 +284,7 @@ select[disabled] > option {
       display: none;
     }
   }
+  .sd-page-content__content-block {
+    width: auto;
+  }
 }


### PR DESCRIPTION
- Output Control view gets cut off on the right side when Editor is open
- sd-loader z-index fix so that its not overlapping other areas
- subnav tenant dropdown margin fix