### PR TITLE
SWP-2351 - Redirect to login page when session expires

### DIFF
--- a/client/components/Dashboard/Dashboard.jsx
+++ b/client/components/Dashboard/Dashboard.jsx
@@ -27,6 +27,9 @@ class Dashboard extends React.Component {
           return s;
         });
         if (this._isMounted) this.setState({ tenants, loading: false });
+      })
+      .catch(() => {
+        if (this._isMounted) this.setState({ loading: false });
       });
   }
 

--- a/client/extensions/Publishing.jsx
+++ b/client/extensions/Publishing.jsx
@@ -53,14 +53,23 @@ class Publishing extends React.Component {
   }
 
   prepare = () => {
-    this.authorize().then((res) => {
-      this.setState(
-        { apiHeader: { Authorization: "Basic " + res.data.token.api_key } },
-        () => {
-          this.evaluate();
+    this.authorize()
+      .then((res) => {
+        this.setState(
+          { apiHeader: { Authorization: "Basic " + res.data.token.api_key } },
+          () => {
+            this.evaluate();
+          }
+        );
+      })
+      .catch((err) => {
+        if (err.response && (err.response.status === 401 || err.response.status === 403)) {
+          this.props.session.expire();
+          this.props.session.getIdentity().then(() => this.prepare());
+          return;
         }
-      );
-    });
+        this.setState({ loading: false });
+      });
   };
 
   authorize = () => {
@@ -89,6 +98,11 @@ class Publishing extends React.Component {
         return res;
       })
       .catch((err) => {
+        if (err.response && (err.response.status === 401 || err.response.status === 403)) {
+          this.props.session.expire();
+          this.props.session.getIdentity().then(() => this.prepare());
+          return;
+        }
         this.setState({
           loading: false,
           evaluateError:

--- a/client/services/PubAPIFactory.js
+++ b/client/services/PubAPIFactory.js
@@ -284,8 +284,17 @@ export function PubAPIFactory(config, $http, $q, session, $location, Upload) {
                     return response.data;
                 }
 
+                console.error('publisher api error', response);
+                return $q.reject(response);
+            }, (response) => {
                 if (response.status === 401 || response.status === 403) {
-                    window.location.reload();
+                    session.expire();
+                    return session.getIdentity().then(() => {
+                        return this.setToken().then(() => {
+                            config.headers = { Authorization: 'Basic ' + this._token };
+                            return $http(config).then((retryResponse) => retryResponse.data);
+                        });
+                    });
                 }
 
                 console.error('publisher api error', response);


### PR DESCRIPTION
**Changes Made**

1. PubAPIFactory.js — Core fix (covers all Publisher API calls)

Problem: The 401/403 check was in the .then() success handler, but Angular's $http rejects on non-2xx responses, so the check was never reached. Errors fell through unhandled, causing infinite loading.

Fix: Added a proper error rejection handler that:
- Calls session.expire() to clear the expired session
- Calls session.getIdentity() which triggers Superdesk's login modal
- After re-authentication, re-exchanges credentials via setToken() for a fresh Publisher API key
- Retries the original request

This mirrors exactly how Superdesk core's AuthExpiredInterceptor works.

2. Publishing.jsx — Handles direct axios calls

This component bypasses PubAPIFactory and uses axios directly. Added 401/403 handling on both prepare() and evaluate() that triggers the same session.expire() → session.getIdentity() → retry flow.

3. Dashboard.jsx — Prevents stuck loading state

Added a .catch() handler so the component exits the loading state on failure instead of spinning forever.