### PR TITLE
SWP-2328 - Manual content list selection menu visual issue fixed

### DIFF
--- a/client/styles/_publisher.scss
+++ b/client/styles/_publisher.scss
@@ -67,6 +67,10 @@
   }
 }
 
+.navbtn.navbtn--text-only {
+  line-height: normal;
+}
+
 .big-number-block {
   &--wrap {
     flex-direction: column;


### PR DESCRIPTION
Line-height: 4.8rem in dropdown menu is overriden with _publisher.scss - line-height: normal 