### PR TITLE
Strip deprecated ~ prefix from SCSS imports

### DIFF
--- a/client/styles/_publisher.scss
+++ b/client/styles/_publisher.scss
@@ -2,8 +2,8 @@
 // Styling for the web publisher module
 // ----------------------------------------------------------------------------------------
 
-@import "~mixins.scss";
-@import "~variables.scss";
+@import "mixins.scss";
+@import "variables.scss";
 @import "uploadFix.scss";
 @import "treeList.scss";
 @import "listElement.scss";


### PR DESCRIPTION
### Purpose
Forward-compat with `sass-loader` 16, which removes the legacy `~` import shim. Lets superdesk-client-core finish migrating off its Dart Sass deprecations without breaking the integrated client build for anyone who pulls publisher via the github dep in `superdesk/client/package.json`.

### What has changed
- Drop the `~` prefix from the two `@import` lines in `client/styles/_publisher.scss`. The bare specifiers still resolve via the same `loadPath`, so the compiled CSS is unchanged.

### Steps to test
- `npm run build` (or whatever the consumer's bundle command is) under a `sass-loader` 10 or 16 client; both should produce identical CSS as before.